### PR TITLE
Using orientationchange event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -155,11 +155,19 @@ device.television = function() {
 }
 
 device.portrait = function() {
-  return window.innerHeight / window.innerWidth > 1
+  if (Object.prototype.hasOwnProperty.call(window, 'onorientationchange')) {
+    return screen.orientation.type.includes('portrait')
+  } else {
+    return window.innerHeight / window.innerWidth > 1
+  }
 }
 
 device.landscape = function() {
-  return window.innerHeight / window.innerWidth < 1
+  if (Object.prototype.hasOwnProperty.call(window, 'onorientationchange')) {
+    return screen.orientation.type.includes('landscape')
+  } else {
+    return window.innerHeight / window.innerWidth < 1
+  }
 }
 
 // Public Utility Functions

--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,7 @@ device.onChangeOrientation = function(cb) {
 // otherwise fall back to the resize event.
 let orientationEvent = 'resize'
 if (Object.prototype.hasOwnProperty.call(window, 'onorientationchange')) {
-  orientationEvent = 'onorientationchange'
+  orientationEvent = 'orientationchange'
 }
 
 // Listen for changes in orientation.


### PR DESCRIPTION
Code has typo in event name. And it fires before width and height changes.