### PR TITLE
fix ios orientation change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,6 +160,12 @@ device.portrait = function() {
   ) {
     return includes(screen.orientation.type, 'portrait')
   }
+  if (
+    device.ios() &&
+    Object.prototype.hasOwnProperty.call(window, 'orientation')
+  ) {
+    return Math.abs(window.orientation) !== 90
+  }
   return window.innerHeight / window.innerWidth > 1
 }
 
@@ -169,6 +175,12 @@ device.landscape = function() {
     Object.prototype.hasOwnProperty.call(window, 'onorientationchange')
   ) {
     return includes(screen.orientation.type, 'landscape')
+  }
+  if (
+    device.ios() &&
+    Object.prototype.hasOwnProperty.call(window, 'orientation')
+  ) {
+    return Math.abs(window.orientation) === 90
   }
   return window.innerHeight / window.innerWidth < 1
 }


### PR DESCRIPTION
Fix for #191 and probably also #180. I fixed it by falling back to `window.orientation` on ios devices as `innerHeight` and `innerWidth` are not updated immediately after the orientation change event is fired. I know this is not the ideal solution as `window.orientation` is deprecated, but I thought it's at least better than having incorrect results.