### PR TITLE
fix: replace for...in enumeration by for(index < length) in walkOnChangeOrientationList

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -307,7 +307,7 @@ function handleOrientation() {
 }
 
 function walkOnChangeOrientationList(newOrientation) {
-  for (const index = 0; index < changeOrientationList.length; index++) {
+  for (let index = 0; index < changeOrientationList.length; index++) {
     changeOrientationList[index](newOrientation)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -307,7 +307,7 @@ function handleOrientation() {
 }
 
 function walkOnChangeOrientationList(newOrientation) {
-  for (const index in changeOrientationList) {
+  for (const index = 0; index < changeOrientationList.length; index++) {
     changeOrientationList[index](newOrientation)
   }
 }


### PR DESCRIPTION
Fixes #216

**Note**: affects all browsers when using third party packages that pollute the array prototype and cannot handle *newOrientation* param.